### PR TITLE
Add receiving of rollout data

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RosSockets"
 uuid = "f2b1035b-1fed-4502-a057-be66ed18c291"
 authors = ["Jacob Levy"]
-version = "0.4.0"
+version = "0.5.0"
 
 [deps]
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"

--- a/README.md
+++ b/README.md
@@ -93,6 +93,37 @@ When complete with tasks, be sure to close the connection:
 close_feedback_connection(feedback_connection)
 ```
 
+### Obtaining Rollout Data
+
+Here, we obtain rollout data (timestamps, states, desired states, and controls) from the `/rollout_data` node from from [ros_sockets](https://github.com/CLeARoboticsLab/ros_sockets).
+
+First, ensure the `/rollout_data` node from from [ros_sockets](https://github.com/CLeARoboticsLab/ros_sockets) is running on the target.
+
+Open a connection to the ROS node, setting `ip` and `port` to match that of the node:
+
+```jl
+ip = "192.168.88.128"
+port = 42425
+rollout_data_connection = open_connection(ip, port)
+```
+
+With the connection open, wait for data to arrive from the ROS node.
+Execution is blocked while waiting, up to the timeout duration (seconds) provided.
+If the timeout duration elapses without the arrival of data, a TimeoutError exception is thrown.
+
+```jl
+timeout = 10.0
+data = rollout_data(rollout_data_connection, timeout)
+```
+
+`rollout_data` returns a named tuple with the following fields: `ts`, `xs`, `xds`, `us`.
+
+When complete with tasks, be sure to close the connection:
+
+```jl
+close_connection(rollout_data_connection)
+```
+
 ### Velocity Control
 
 First, ensure the `/velocity_control` node from from [ros_sockets](https://github.com/CLeARoboticsLab/ros_sockets) is running on the target.

--- a/examples/rollout_data_barebones_example.jl
+++ b/examples/rollout_data_barebones_example.jl
@@ -1,0 +1,31 @@
+# In this example, a connection for rollout data from a ROS node is opened and
+# the program waits for data to arrive. When data arrives, the data is printed,
+# and then the connection is closed.
+
+using RosSockets
+
+function run_example()
+
+    ip = "192.168.1.223"    # ip address of the host of the ROS node
+    port = 42425            # port to connect on
+    timeout = 10.0  # maximum seconds to wait for data with rollout_data
+
+    # Open listener for rollout data from the ROS node
+    rollout_data_connection = open_connection(ip, port)
+
+    # Wait for data to arrive from the ROS node. Execution is blocked while
+    # waiting, up to the timout duration provided. If the timeout duration
+    # elapses without the arrival of data, throws a TimeoutError exception.
+    data = rollout_data(rollout_data_connection, timeout)
+
+    # Print each data field to console
+    println("Times: $(data.ts)")
+    println("States: $(data.xs)")
+    println("Desired states: $(data.xds)")
+    println("Control inputs: $(data.us)")
+
+    # Close the listener
+    close_connection(rollout_data_connection)
+end
+
+run_example()

--- a/src/RosSockets.jl
+++ b/src/RosSockets.jl
@@ -17,5 +17,8 @@ export FeedbackData,
     open_feedback_connection,
     receive_feedback_data,
     close_feedback_connection
+    
+include("rollout_data.jl")
+export rollout_data
 
 end # module RosSockets

--- a/src/rollout_data.jl
+++ b/src/rollout_data.jl
@@ -1,0 +1,23 @@
+const GET_ROLLOUT_DATA = JSON.json(Dict("action" => "get_rollout_data")) * "\n"
+
+"""
+    rollout_data(connection::Connection)
+
+Get the rollout data from the ROS node. Returns a named tuple of vectors and
+matrices of the following:
+
+- ts: vector of times
+- xs: matrix of states (# states by # timesteps)
+- xds: matrix of desired states (# states by # timesteps)
+- us: matrix of control inputs (# inputs by # timesteps)
+"""
+function rollout_data(connection::Connection, timeout::Real = 10.0)
+    payload = send_receive(connection, GET_ROLLOUT_DATA, timeout)
+    data = JSON.parse(String(payload))
+    return (
+        ts = convert(Vector{Float64}, data["ts"]),
+        xs = convert(Matrix{Float64}, reduce(hcat,data["xs"])),
+        xds = convert(Matrix{Float64}, reduce(hcat,data["xds"])),
+        us = convert(Matrix{Float64}, reduce(hcat,data["us"]))
+    )
+end


### PR DESCRIPTION
Added `rollout_data` function which obtains rollout data (timestamps, states, desired states, and controls) from the `/rollout_data` node from from [ros_sockets](https://github.com/CLeARoboticsLab/ros_sockets).